### PR TITLE
Fixed: Django 2.0 rel field deprecated

### DIFF
--- a/salmonella/admin.py
+++ b/salmonella/admin.py
@@ -6,14 +6,24 @@ class SalmonellaMixin(object):
 
     def formfield_for_foreignkey(self, db_field, request=None, **kwargs):
         if db_field.name in self.salmonella_fields:
-            kwargs['widget'] = SalmonellaIdWidget(db_field.rel, self.admin_site)
+            if hasattr(db_field, 'model'):
+                rel = db_field.model
+            else:
+                rel = db_field.rel
+
+            kwargs['widget'] = SalmonellaIdWidget(rel, self.admin_site)
             return db_field.formfield(**kwargs)
         return super(SalmonellaMixin, self).formfield_for_foreignkey(
             db_field, request, **kwargs)
 
     def formfield_for_manytomany(self, db_field, request=None, **kwargs):
         if db_field.name in self.salmonella_fields:
-            kwargs['widget'] = SalmonellaMultiIdWidget(db_field.rel, self.admin_site)
+            if hasattr(db_field, 'model'):
+                rel = db_field.model
+            else:
+                rel = db_field.rel
+
+            kwargs['widget'] = SalmonellaMultiIdWidget(rel, self.admin_site)
             kwargs['help_text'] = ''
             return db_field.formfield(**kwargs)
         return super(SalmonellaMixin, self).formfield_for_manytomany(db_field,

--- a/salmonella/filters.py
+++ b/salmonella/filters.py
@@ -31,7 +31,12 @@ class SalmonellaFilter(admin.filters.FieldListFilter):
         self.lookup_kwarg = '%s' % field_path
         super(SalmonellaFilter, self).__init__(
             field, request, params, model, model_admin, field_path)
-        self.form = self.get_form(request, field.rel, model_admin.admin_site)
+        if hasattr(field, 'remote_field'):
+            rel = field.remote_field
+        else:
+            rel = field.rel
+
+        self.form = self.get_form(request, rel, model_admin.admin_site)
 
     def choices(self, cl):
         """Filter choices are not available."""

--- a/salmonella/widgets.py
+++ b/salmonella/widgets.py
@@ -32,15 +32,21 @@ class SalmonellaIdWidget(widgets.ForeignKeyRawIdWidget):
         if attrs is None:
             attrs = {}
 
+        rel = self.rel
+        if hasattr(rel, 'model'):
+            model = rel.model
+        else:
+            model = rel.to
+
         try:
             related_url = reverse('admin:%s_%s_changelist' % (
-                self.rel.to._meta.app_label,
-                self.rel.to._meta.object_name.lower()),
+                model._meta.app_label,
+                model._meta.object_name.lower()),
                 current_app=self.admin_site.name)
         except NoReverseMatch:
             raise SalmonellaImproperlyConfigured('The model %s.%s is not '
-                'registered in the admin.' % (self.rel.to._meta.app_label,
-                                              self.rel.to._meta.object_name))
+                'registered in the admin.' % (model._meta.app_label,
+                                              model._meta.object_name))
 
         params = self.url_parameters()
         if params:
@@ -49,8 +55,8 @@ class SalmonellaIdWidget(widgets.ForeignKeyRawIdWidget):
             url = u''
         if "class" not in attrs:
             attrs['class'] = 'vForeignKeyRawIdAdminField'  # The JavaScript looks for this hook.
-        app_name = self.rel.to._meta.app_label.strip()
-        model_name = self.rel.to._meta.object_name.lower().strip()
+        app_name = model._meta.app_label.strip()
+        model_name = model._meta.object_name.lower().strip()
         hidden_input = super(widgets.ForeignKeyRawIdWidget, self).render(name, value, attrs)
 
         extra_context = {
@@ -71,15 +77,21 @@ class SalmonellaIdWidget(widgets.ForeignKeyRawIdWidget):
         """
         context = super(SalmonellaIdWidget, self).get_context(name, value, attrs)
 
+        rel = self.rel
+        if hasattr(rel, 'model'):
+            model = rel.model
+        else:
+            model = rel.to
+
         try:
             related_url = reverse('admin:%s_%s_changelist' % (
-                self.rel.to._meta.app_label,
-                self.rel.to._meta.object_name.lower()),
+                model._meta.app_label,
+                model._meta.object_name.lower()),
                 current_app=self.admin_site.name)
         except NoReverseMatch:
             raise SalmonellaImproperlyConfigured('The model %s.%s is not '
-                'registered in the admin.' % (self.rel.to._meta.app_label,
-                                              self.rel.to._meta.object_name))
+                'registered in the admin.' % (model._meta.app_label,
+                                              model._meta.object_name))
 
         params = self.url_parameters()
         if params:
@@ -88,8 +100,8 @@ class SalmonellaIdWidget(widgets.ForeignKeyRawIdWidget):
             url = u''
         if "class" not in attrs:
             attrs['class'] = 'vForeignKeyRawIdAdminField'  # The JavaScript looks for this hook.
-        app_name = self.rel.to._meta.app_label.strip()
-        model_name = self.rel.to._meta.object_name.lower().strip()
+        app_name = model._meta.app_label.strip()
+        model_name = model._meta.object_name.lower().strip()
 
         context.update({
             'name': name,


### PR DESCRIPTION
This commit fixes the deprecation of the `rel` field on Django 2.0 models.

Fixes #39